### PR TITLE
Executed commands don't include configured CMVC binary path

### DIFF
--- a/src/main/java/hudson/plugins/cmvc/CmvcSCM.java
+++ b/src/main/java/hudson/plugins/cmvc/CmvcSCM.java
@@ -418,6 +418,7 @@ public class CmvcSCM extends SCM implements Serializable {
 	public void buildEnvVars(AbstractBuild build, Map<String, String> env) {
 		super.buildEnvVars(build, env);
 		
+		env.put("CMVC_CLIENT_CMC", DESCRIPTOR.cmvcPath);
 		env.put("CMVC_FAMILY", this.family);
 		env.put("CMVC_RELEASES", this.releases);
 		if (StringUtils.isNotEmpty(this.become)){

--- a/src/main/java/hudson/plugins/cmvc/util/CommandLineUtil.java
+++ b/src/main/java/hudson/plugins/cmvc/util/CommandLineUtil.java
@@ -6,6 +6,7 @@ import hudson.plugins.cmvc.CmvcSCM;
 import hudson.plugins.cmvc.CmvcChangeLogSet.CmvcChangeLog;
 import hudson.util.ArgumentListBuilder;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -105,7 +106,7 @@ public class CommandLineUtil {
 
 	private ArgumentListBuilder buildBasicRawReportCommand(String viewName) {
 		ArgumentListBuilder command = new ArgumentListBuilder();
-		command.add("Report");
+		command.add( getFullyQualifiedCommand( "Report" ));
 		command.add("-family");
 		command.add(cmvcSCM.getFamily());
 
@@ -118,6 +119,18 @@ public class CommandLineUtil {
 		command.add("-view");
 		command.add(viewName);
 		return command;
+	}
+
+	/**
+	 * Given a desired CMVC command, such as "Report", return the fully-qualified
+	 * path to this command based on the CMVC path descriptor in the configuration.
+	 * 
+	 * @param command
+	 * @return
+	 */
+	private String getFullyQualifiedCommand( String command ) {
+		String path = ((CmvcSCM.DescriptorImpl)cmvcSCM.getDescriptor()).getCmvcPath();
+		return path + File.separator + command;
 	}
 
 	/**

--- a/src/main/java/hudson/plugins/cmvc/util/DateUtil.java
+++ b/src/main/java/hudson/plugins/cmvc/util/DateUtil.java
@@ -14,7 +14,7 @@ import java.util.Date;
 public class DateUtil {
     
     /** Date format expected by CMVC */
-    private static final String CMVC_DATE_FORMAT_INOUT = "yy/MM/dd HH:mm:ss";
+    private static final String CMVC_DATE_FORMAT_INOUT = "yyyy/MM/dd HH:mm:ss";
     
     private static final SimpleDateFormat SDF = new SimpleDateFormat(CMVC_DATE_FORMAT_INOUT);
     /** A working calendar. */
@@ -59,8 +59,7 @@ public class DateUtil {
     public static String convertToCmvcDate(Date lastBuild) {
     	if (lastBuild != null) {
     		CALENDAR.setTime(lastBuild);
-    		String sufix = CALENDAR.get(Calendar.YEAR) < 2000 ? "0" : "1";
-    		return "'" + sufix + SDF.format(lastBuild) + "'";
+    		return "'" + SDF.format( lastBuild ) + "'";
     	}
     	return null;
     }


### PR DESCRIPTION
Although the CMVC plugin takes the CMVC executables directory as a configuration option, this directory isn't used when executing the actual commands.  This leads to the following error:

```
FATAL: Error performing checkout: Cannot run program "Report" (in directory "/var/lib/jenkins/jobs/tspm710.policy/workspace"): java.io.IOException: error=2, No such file or directory
Finished: FAILURE
```
